### PR TITLE
Fix SavvyCAN compatibility by making Open command idempotent

### DIFF
--- a/arduino-canbus-monitor/can-232.cpp
+++ b/arduino-canbus-monitor/can-232.cpp
@@ -177,7 +177,7 @@ INT8U Can232::parseAndRunCommand() {
             }
         }
         else {
-            ret = LW232_ERR;
+            ret = LW232_OK;
         }
         break;
         case LW232_CMD_LISTEN:


### PR DESCRIPTION
The device was returning an error when it received an "Open" command while the CAN channel was already open. This caused issues with SavvyCAN, which sends an "Open" command on startup.

This change modifies the "Open" command handler to return success even if the channel is already open. This makes the command idempotent and allows both SavvyCAN and the original CANHacker software to work correctly.

Fix by @oracoll 
